### PR TITLE
Feat: 1주차 해시 문제풀이

### DIFF
--- a/problems/1주차_해시/완주하지못한선수/준상.js
+++ b/problems/1주차_해시/완주하지못한선수/준상.js
@@ -1,0 +1,22 @@
+function solution(participant, completion) {
+    let answer = '';
+    let participantMap = new Map();
+    for (const x of participant) {
+        if (participantMap.get(x)) {
+            participantMap.set(x, participantMap.get(x) + 1);
+        } else {
+            participantMap.set(x, 1);
+        }
+    }
+    
+    for (const x of completion) {
+        if (participantMap.get(x) > 1) {
+            participantMap.set(x, participantMap.get(x) - 1);
+        } else {
+            participantMap.delete(x);
+        }
+    }
+    
+    participantMap.forEach((value, key) => answer += key);
+    return answer;
+}

--- a/problems/1주차_해시/위장/준상.js
+++ b/problems/1주차_해시/위장/준상.js
@@ -1,0 +1,16 @@
+function solution(clothes) {
+    let answer = 1;
+    let clothesMap = new Map();
+    clothes.map(([item, part]) => {
+        if (clothesMap.has(part)) {
+            clothesMap.set(part, clothesMap.get(part) + 1);
+        } else {
+            clothesMap.set(part, 1);
+        }
+    })
+    for (const x of clothesMap) {
+        answer *= (x[1] + 1);
+    }
+    
+    return answer - 1;
+}

--- a/problems/1주차_해시/폰켓몬/준상.js
+++ b/problems/1주차_해시/폰켓몬/준상.js
@@ -1,0 +1,18 @@
+function solution(nums) {
+    let answer = 0;
+    let monMap = new Map();
+    for (const x of nums) {
+        if (monMap.has(x)) {
+            monMap.set(x, monMap.get(x) + 1);
+        } else {
+            monMap.set(x, 1);
+        }
+    }
+    
+    if (monMap.size >= nums.length / 2) {
+        answer = nums.length / 2;
+    } else {
+        answer = monMap.size;
+    }
+    return answer;
+}


### PR DESCRIPTION
## 푼 문제
* 완주하지 못한 선수
* 폰켓몬
* 위장

## 문제 풀이 핵심
### 완주하지 못한 선수
* 참가자 이름을 `key`로 하고, 명수를 `value`로 하는 `map` 자료형인 `participantMap` 을 만들었습니다.
```javascript
let participantMap = new Map();
for (const x of participant) {
    if (participantMap.get(x)) {
        participantMap.set(x, participantMap.get(x) + 1);
    } else {
        participantMap.set(x, 1);
    }
}
```
* 완주한 선수를 배열로 담은 `completion`을 순회하면서 동명이인이라면 `1`을 빼고, 아니라면 `map` 자료형에서 제거하였습니다.
```javascript
for (const x of completion) {
    if (participantMap.get(x) > 1) {
        participantMap.set(x, participantMap.get(x) - 1);
    } else {
        participantMap.delete(x);
    }
 }
```

### 폰켓몬
* 각 몬스터의 번호를 `key`로, 마리 수를 `value`로 지정한 `map`을 선언하고, `map` 자료형의 장점인 `size` 메서드를 사용하여 풀었습니다.
```javascript
let monMap = new Map();
for (const x of nums) {
    if (monMap.has(x)) {
        monMap.set(x, monMap.get(x) + 1);
    } else {
        monMap.set(x, 1);
    }
}
    
if (monMap.size >= nums.length / 2) {
    answer = nums.length / 2;
} else {
    answer = monMap.size;
}
```

### 위장
* `해시`의 개념보다 수학적 개념이 푸는데에 더 중요한 문제라고 생각합니다. 이 방법을 떠올리는데 시간이 꽤 걸렸습니다.
* 역시 종류를 `key`로 상품 수를 `value`로 지정한 `map` 자료형을 선언하였습니다.
* 가장 중요한 논리인데, 입을 수 있는 가지 수를 **`상품 수 + 1`를 모두 곱하고, 아예 입지 않는 경우 `1`을 빼서 구했습니다.**
```javascript
    let clothesMap = new Map();
    clothes.map(([item, part]) => {
        if (clothesMap.has(part)) {
            clothesMap.set(part, clothesMap.get(part) + 1);
        } else {
            clothesMap.set(part, 1);
        }
    })
```
```javascript
    for (const x of clothesMap) {
        answer *= (x[1] + 1);
    }
    
    return answer - 1;
``` 

## 인증 사진
![해시](https://user-images.githubusercontent.com/89122773/196219201-173076c1-da86-4db7-8cd8-b748993f9313.png)
