### PR TITLE
[6주차_완전탐색] 문제풀이

### DIFF
--- a/problems/6주차_완전탐색/모의고사/형겸.js
+++ b/problems/6주차_완전탐색/모의고사/형겸.js
@@ -1,20 +1,23 @@
 function solution(answers) {
   let answer = [];
+  // 각 학생들의 찍는 방식을 담은 배열
   let student = [
     [1, 2, 3, 4, 5],
     [2, 1, 2, 3, 2, 4, 2, 5],
     [3, 3, 1, 1, 2, 2, 4, 4, 5, 5],
   ];
 
-  let score = [];
+  let score = []; // 각 학생의 맞은 갯수를 담는 배열
   for (let i = 0; i < student.length; i++) {
+    // 맞은 갯수를 구하는 반복문
     score[i] = answers.filter(
       (problem, idx) => problem === student[i][idx % student[i].length]
     ).length;
   }
 
-  let max = Math.max(...score);
+  let max = Math.max(...score); // 이 중 제일 많이 맞은 갯수를 max 에 담아준다.
 
+  // score 배열의 각 학생의 정답 수가 max 와 같으면 해당 학생 번호 answer에 push
   if (score[0] === max) answer.push(1);
   if (score[1] === max) answer.push(2);
   if (score[2] === max) answer.push(3);

--- a/problems/6주차_완전탐색/최소직사각형/형겸.js
+++ b/problems/6주차_완전탐색/최소직사각형/형겸.js
@@ -1,13 +1,15 @@
 function solution(sizes) {
+  // 너비, 높이를 담아줄 배열
   let w = [];
   let h = [];
   for (let size of sizes) {
-    size.sort((a, b) => a - b);
-    w.push(size[0]);
-    h.push(size[1]);
+    // sizes 배열 인덱스 반복
+    size.sort((a, b) => a - b); // compareFunction 을 이용해 오름차순 정렬
+    w.push(size[0]); // 둘 중 작은 값 w 에 push
+    h.push(size[1]); // 둘 중 큰 값 h 에 push
   }
-  w.sort((a, b) => a - b);
-  h.sort((a, b) => a - b);
+  w.sort((a, b) => a - b); // w 배열을 오름차순 정렬
+  h.sort((a, b) => a - b); // h 배열을 오름차순 정렬
 
-  return w[w.length - 1] * h[h.length - 1];
+  return w[w.length - 1] * h[h.length - 1]; // 각 배열의 최댓값을 곱한 값을 return
 }


### PR DESCRIPTION
## 최소직사각형
- 모든 카드의 너비, 높이 중 최댓값을 곱해주면 답이 나오는 간단한 문제였음.
- 각 배열을 전부 오름차순 정렬하고, 너비, 높이 배열에 담아주고 다시 오름차순 정렬 후, 인덱스 마지막 값(최댓값) 을 곱해주는 방식으로 답을 구함.
- 계속 테스트케이스에서 실패가 뜨길래 뭔가 했더니 정렬 파트에서 짚고 넘어갔던 `compareFunction` 이 문제였다는 것을 생각해냄, 
- PR 쓰면서 생각하는데, 이미 오름차순인 원소까지 정렬을 돌려야 하나 하는 의문이 들어 조건문을 만들어 주어서 **인덱스 0 번과 1번을 비교해서 해당하는 원소만 오름차순 정렬** 하는 방법은 어떨까 싶다!
```Js
function solution(sizes) {
  // 너비, 높이를 담아줄 배열
  let w = [];
  let h = [];
  for (let size of sizes) {
    // sizes 배열 인덱스 반복
    size.sort((a, b) => a - b); // compareFunction 을 이용해 오름차순 정렬
    w.push(size[0]); // 둘 중 작은 값 w 에 push
    h.push(size[1]); // 둘 중 큰 값 h 에 push
  }
  w.sort((a, b) => a - b); // w 배열을 오름차순 정렬
  h.sort((a, b) => a - b); // h 배열을 오름차순 정렬

  return w[w.length - 1] * h[h.length - 1]; // 각 배열의 최댓값을 곱한 값을 return
}
```

<br/>

## 모의고사
- 각 학생들이 찍는 방식과 문제 답안의 원소의 값을 비교하여 맞은 갯수를 `score` 배열에 담아주었음
- 그 후 `score` 의 최댓값을 `max` 변수로 선언해주고 `max` 와 같은 수를 가진 `score` 를 비교하여 맞으면 해당 학생의 번호를 `answer` 에 담아주면 끝
- `filter` 가 효율면에서 떨어진다고 한다. 다른 풀이를 찾아보니 `let  score = [0, 0, 0]` 이런식으로 초기화를 해준 후 문제 배열을 반복해서 맞으면 `score` 의 수를 1씩 올려주는 방식으로 풀더라 이렇게 풀면 효율면에서 이득을 본다고 한다.
```Js
function solution(answers) {
  let answer = [];
  // 각 학생들의 찍는 방식을 담은 배열
  let student = [
    [1, 2, 3, 4, 5],
    [2, 1, 2, 3, 2, 4, 2, 5],
    [3, 3, 1, 1, 2, 2, 4, 4, 5, 5],
  ];

  let score = []; // 각 학생의 맞은 갯수를 담는 배열
  for (let i = 0; i < student.length; i++) {
    // 맞은 갯수를 구하는 반복문
    score[i] = answers.filter(
      (problem, idx) => problem === student[i][idx % student[i].length]
    ).length;
  }

  let max = Math.max(...score); // 이 중 제일 많이 맞은 갯수를 max 에 담아준다.

  // score 배열의 각 학생의 정답 수가 max 와 같으면 해당 학생 번호 answer에 push
  if (score[0] === max) answer.push(1);
  if (score[1] === max) answer.push(2);
  if (score[2] === max) answer.push(3);

  return answer;
}
```

<br/>

![image](https://user-images.githubusercontent.com/97586683/204772054-775d9e92-8605-4898-8275-334c118fdf66.png)
